### PR TITLE
[MRK-3106]Set max receive message length

### DIFF
--- a/Clarifai/Channels/ClarifaiChannel.cs
+++ b/Clarifai/Channels/ClarifaiChannel.cs
@@ -6,12 +6,14 @@ namespace Clarifai.Channels
     {
         public static Channel Grpc(string url = "api.clarifai.com")
         {
-            return new Channel(url, 443, new SslCredentials());
+            var maxReceiveMessageSizeOption = new ChannelOption(ChannelOptions.MaxReceiveMessageLength, 128 * 1024 * 1024); // 128 MB
+            return new Channel(url, 443, new SslCredentials(), new [] { maxReceiveMessageSizeOption });
         }
 
         public static Channel InsecureGrpc()
         {
-            return new Channel("api-grpc.clarifai.com", 18080, ChannelCredentials.Insecure);
+            var maxReceiveMessageSizeOption = new ChannelOption(ChannelOptions.MaxReceiveMessageLength, 128 * 1024 * 1024); // 128 MB
+            return new Channel("api-grpc.clarifai.com", 18080, ChannelCredentials.Insecure, new [] { maxReceiveMessageSizeOption });
         }
     }
 }


### PR DESCRIPTION
Set the grpc channel max message length to 128MB.